### PR TITLE
fix(template): 在调用下载时才会判断手机存储空间剩余

### DIFF
--- a/packages/syberos-template/com/syberos/api/src/util/downloadmanager.cpp
+++ b/packages/syberos-template/com/syberos/api/src/util/downloadmanager.cpp
@@ -191,6 +191,15 @@ qint64 DownloadManager::downloadFileSize(){
     return m_bytesTotal;
 }
 
+//获取存储空间剩余
+qint64 DownloadManager::storageFreeSize(){
+    if(m_storageFreeSize > 0){
+        return m_storageFreeSize;
+    }
+    m_storageFreeSize = m_storageManager->storageFreeSize(m_storage==Extended ? CStorageManager::ExtStorage : CStorageManager::IntStorage);
+    return m_storageFreeSize;
+}
+
 
 // 下载进度信息
 void DownloadManager::onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal){
@@ -207,7 +216,7 @@ void DownloadManager::onReadyRead(){
     if (!m_isStop) {
         QFile file(m_fileName);
         if (file.open(QIODevice::WriteOnly | QIODevice::Append)) {
-            qint64 free = m_storageManager->storageFreeSize(m_storage==Extended ? CStorageManager::ExtStorage : CStorageManager::IntStorage);
+            qint64 free = storageFreeSize();
             qint64 size = downloadFileSize();
             if(size > free){
                 qDebug() << Q_FUNC_INFO << "存储空间不足，预期：" << size << "，实际可用：" << free << endl;

--- a/packages/syberos-template/com/syberos/api/src/util/downloadmanager.h
+++ b/packages/syberos-template/com/syberos/api/src/util/downloadmanager.h
@@ -67,9 +67,12 @@ private:
     bool m_isStop;
     QString m_downloadId;
     Storage m_storage;  //存储位置
+    qint64 m_storageFreeSize;   //存储空间剩余
     CStorageManager *m_storageManager;
     //获取下载文件的大小
     qint64 downloadFileSize();
+    //获取存储空间剩余
+    qint64 storageFreeSize();
 
 signals:
     void signalDownloadProcess(QString downloadId, QString path, qint64 bytesReceived, qint64 bytesTotal);


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
fix(template): 在调用下载时才会判断手机存储空间剩余
**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 master 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://github.com/angular/angular.js/blob/f3377da6a748007c11fde090890ee58fae4cefa5/CONTRIBUTING.md#commit)
- [ ] 所有测试用例已经通过
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下模块:**

- [ ] syberos-cli
- [ ] syberos-bridge
- [x] syberos-template
- [ ] syberos-dev-server
- [ ] syberos-docs

**其它需要 Reviewer 或社区知晓的内容：**
